### PR TITLE
Bump compability to v9

### DIFF
--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
 		"chat-notifications.css"
 	],
 	"minimumCoreVersion": "0.8.4",
-	"compatibleCoreVersion": "0.8.8",
+	"compatibleCoreVersion": "9",
 	"manifest": "https://raw.githubusercontent.com/Moerill/fvtt-chat-notifications/master/module.json",
 	"download": "https://github.com/Moerill/fvtt-chat-notifications/releases/download/v1.2.3/v1.2.3.zip",
 	"url": "https://github.com/Moerill/fvtt-chat-notifications"


### PR DESCRIPTION
This mod seems to be working fine in Foundry V9, there are also no tickets currently pending on it connected to changes in V9. I suggest updating the compatibleCoreVersion to get rid of the Compatibility Risk warning